### PR TITLE
Hackathon UI Changes + React Update + createRoot

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,12 @@
     "date-fns": "^2.28.0",
     "global": "^4.4.0",
     "ngrok": "^5.0.0-beta.2",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-icons": "^5.2.1",
     "react-router-dom": "6",
     "react-scripts": "3.4.0",
-    "react-typical": "^0.1.3",
-    "yarn": "^1.22.19"
+    "react-typical": "^0.1.3"
   },
   "scripts": {
     "start": "react-scripts --openssl-legacy-provider start",

--- a/src/components/AccordionItem.jsx
+++ b/src/components/AccordionItem.jsx
@@ -1,32 +1,17 @@
 import React from 'react';
 import '../styles/accordion.css';
 
-export default class AccordionItem extends React.Component{
-    constructor(props) {
-        super(props)
-        this.toggleActive= this.toggleActive.bind(this);
+export default function AccordionItem(i, title, text, open, tog) {
+
+    const toggle = () => {
+        i.tog(i.i);
     }
 
-    state = {
-        active : false,
-    }
-
-    toggleActive() {
-        const curState = this.state.active;
-        console.log(this.state.active)
-        this.setState({ active: !curState });
-    }
-
-    render() {
-        return(
-            <>
-                <div className={this.state.active ? 'accordion-container-long': 'accordion-container-short'} onClick={this.toggleActive}>
-                    <div className="accordion-title">{this.props.title}</div>
-                    <div className={this.state.active ? 'accordion-text': 'accordion-text-hidden'}>
-                        {this.props.text}
-                    </div>
-                </div>
-            </>
-        )
-    }
+    return <div className={i.open ? 'accordion-container-long': 'accordion-container-short'} onClick={toggle}>
+        <div className="accordion-title">{i.title}</div>
+        <div className={i.open ? 'accordion-text': 'accordion-text-hidden'}>
+            {i.text}
+        </div>
+    </div>
 }
+

--- a/src/containers/FAQ.jsx
+++ b/src/containers/FAQ.jsx
@@ -1,22 +1,56 @@
-import React from 'react';
+import React, { useState } from 'react';
 import AccordionItem from '../components/AccordionItem';
 import '../styles/FAQ.css';
 
-export default class FAQ extends React.Component{
-    render(){
-        return(
-        <div className="faq-container" id = "FAQ">
+export default function FAQ() {
+    const [OPen, setOPen] = useState(-1);
+
+    function toggleDetails(a) {
+        setOPen(a);
+    }
+
+    const data = [
+        [
+            "What is a hackathon?",
+            "A hackathon is a sprint-like event in which programmers collaborate to solve challenges. Our event specifically involves challenges surrounding bioinformatics, cheminformatics, and drug discovery."
+        ],
+        [
+            "Who is this event for?",
+            "Students from all backgrounds are welcome at PharmaHacks. No extensive knowledge of programming or biomedical sciences is necessary."
+        ],
+    [
+            "Is the event free?",
+            "Yes! The event will be free thanks to our amazing sponsors."
+        ],
+            [
+            "Can students from all universities participate?",
+            "Yes, PharmaHacks is open to students from all universities and CEGEPs."
+        ],
+    [
+            "What’s the duration of the event?",
+            "The event will be during the weekend of March 16-17, 2024."
+        ],
+    [
+            "Will there be prizes?",
+            "Yes!"
+        ]
+    ];
+
+
+        return <div className="faq-container" id = "FAQ">
             <div className="faq-title">We're often asked</div>
 
-            <AccordionItem title={"What is a hackathon?"} text= {"A hackathon is a sprint-like event in which programmers collaborate to solve challenges. Our event specifically involves challenges surrounding bioinformatics, cheminformatics, and drug discovery."}/>
-            <AccordionItem title={"Who is this event for?"} text={"Students from all backgrounds are welcome at PharmaHacks. No extensive knowledge of programming or biomedical sciences is necessary."} />
-            <AccordionItem title={"Is the event free?"} text={"Yes! The event will be free thanks to our amazing sponsors."} />
-            <AccordionItem title={"Can students from all universities participate?"} text={"Yes, PharmaHacks is open to students from all universities and CEGEPs."} />
-            <AccordionItem title={"What’s the duration of the event?"} text={"The event will be during the weekend of March 16-17, 2024. "} />
-            <AccordionItem title={"Will there be prizes?"} text={"Yes!"} />
+            {data.map((item, index) => (
+                <AccordionItem key={index}
+                    i={index}
+                    open={index === OPen}
+                    tog={toggleDetails}
+                    title={item[0]}
+                    text={item[1]}
+                />
+            ))}
 
             <div className="faq-additional">Don't see your question? Ask us <a href="https://www.m.me/StudentPharma" target="_blank" rel="noopener noreferrer">here</a></div>
            
-        </div>        
-    )}
+        </div>;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './styles/index.css';
 import Hackathon from './pages/Hackathon';
 import Team from './pages/Team';
@@ -8,9 +8,13 @@ import Event from './pages/Event';
 import Navbar from './containers/Navbar';
 import * as serviceWorker from './serviceWorker';
 import {BrowserRouter, Routes, Route} from "react-router-dom";
+const domNode = document.getElementById('root');
+const root = createRoot(domNode);
+root.render(<App />);
+serviceWorker.register();
 
-ReactDOM.render(
-    <>
+function App() {
+    return <>
         <Navbar />
         <BrowserRouter>
             <Routes>
@@ -20,7 +24,5 @@ ReactDOM.render(
                 <Route path = "/Event" element = {<Event />} />
             </Routes>
         </BrowserRouter>
-    </>
-    , document.getElementById("root"))
-    
-serviceWorker.register();
+    </>;
+}

--- a/src/styles/HackathonWelcome.css
+++ b/src/styles/HackathonWelcome.css
@@ -10,7 +10,8 @@
 .hwelcome-container{
     background-color: #000D1B;
     max-width: 100vw;
-    min-height: 80vh;
+    min-height: 100vh;
+    height: max-content;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
What did I do?

- Updated React to 18.3.1 (latest on npm) so that:
     - reduce vulnerabilities.
     - gain access to useState.
     - update rendering to use createRoot.

- Updated UI of Hackathon Page
     - **TOTALLY NECESSARY** Made sure the title related to "approaching the next event" was visible at all times (through altering of max-height: 80vh to 100vh on '.hwelcome-container').
     - **NOT NECESSARY but...** did add functionality to the FAQ (allows only one FAQ item to be open at a time), I believe it improves the experience of the site.

Why did I do it?
- Saw the project on Onur Gul's page and felt like contributing to something, ya know, always good to feel comfortable in other codebases.
- This is my first time contributing so I hope I didn't do a horrendous job... Although I do apologize for not committing between upgrading React, updating to createRoot, and second UI change (single FAQ) for Hackathon Page.